### PR TITLE
fix: Don't create dynamic property in Dispatcher

### DIFF
--- a/lib/Dispatcher.php
+++ b/lib/Dispatcher.php
@@ -39,6 +39,10 @@ class Dispatcher
      * @var \phpDocumentor\Reflection\Types\ContextFactory
      */
     private $contextFactory;
+    /**
+     * @var JsonMapper
+     */
+    private $mapper;
 
     /**
      * @param object $target    The target object that should receive the method calls


### PR DESCRIPTION
https://wiki.php.net/rfc/deprecate_dynamic_properties causes this to emit an E_DEPRECATION notice in php 8.2+ and this will throw an Error in php 9.0

A private property was chosen because:
- This was undocumented and I assume unintentional.
- This will not conflict with any properties of the same name and different types (or readonly properties) in subclasses.